### PR TITLE
Better GitHub Syntax Highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.reds linguist-language=swift


### PR DESCRIPTION
Super small PR for some GitHub QoL

Since this repo has a lot of redscript adding the `.gitattributes` file and forcing the syntax highlighting to that for Swift will make it much easier to read online. This might also be useful on other redscript repos as well, so feel free to steal it for them