### PR TITLE
✨ Skip Vanilla Items that Already Have OutfitSlots

### DIFF
--- a/scripts/OutfitConfig.reds
+++ b/scripts/OutfitConfig.reds
@@ -109,6 +109,19 @@ public abstract class OutfitConfig {
         ExtraSlotConfig.Create(n"OutfitSlots.BodyOuter", 10, t"AttachmentSlots.Torso")
     ];
 
+    public static func OutfitSlotMap() -> ref<inkIntHashMap> {
+        let map = new inkIntHashMap();
+        let outfitSlots = OutfitConfig.OutfitSlots();
+
+        let i = 0;
+        for slot in outfitSlots {
+            map.Insert(TDBID.ToNumber(slot.slotID), i);
+            i += 1;
+        }
+
+        return map;
+    }
+
     public static func AppearanceSuffixes() -> array<AppearanceSuffixConfig> = [
         AppearanceSuffixConfig.Create(n"itemsFactoryAppearanceSuffix.LegsState", n"EquipmentEx.PuppetStateSystem", n"GetLegsStateSuffix")
     ];

--- a/scripts/Tweaks/PatchOriginaltems.reds
+++ b/scripts/Tweaks/PatchOriginaltems.reds
@@ -3,6 +3,7 @@ module EquipmentEx
 class PatchOriginaltems extends ScriptableTweak {
     protected func OnApply() -> Void {
         let outfitSlots = OutfitConfig.OutfitSlots();
+        let outfitSlotMap = OutfitConfig.OutfitSlotMap();
         let slotMatcher = OutfitSlotMatcher.Create();
 
         slotMatcher.IgnoreEntities([
@@ -91,8 +92,21 @@ class PatchOriginaltems extends ScriptableTweak {
             let garmentOffset = item.GarmentOffset();
             let updated = false;
 
+            let alreadyTweaked = false;
+            for placementSlot in placementSlots {
+                if outfitSlotMap.KeyExist(TDBID.ToNumber(placementSlot)) {
+                    let slot = outfitSlots[outfitSlotMap.Get(TDBID.ToNumber(placementSlot))];
+
+                    LogChannel(n"Debug", s"Found already tweaked vanilla item \(slot.displayName): \(NameToString(slot.slotName))");
+                    garmentOffset = slot.garmentOffset;
+                    updated = true;
+                    alreadyTweaked = true;
+                    break;
+                }
+            }
+
             let outfitSlotID = slotMatcher.Match(item);
-            if TDBID.IsValid(outfitSlotID) {
+            if TDBID.IsValid(outfitSlotID) && !alreadyTweaked {
                 for outfitSlot in outfitSlots {
                     if outfitSlot.slotID == outfitSlotID {
                         if !ArrayContains(placementSlots, outfitSlot.slotID) {


### PR DESCRIPTION
This enables adding or changing slots for vanilla items with just a tweak.

A terrible implementation but maybe conveys the idea if nothing else.