### PR TITLE
Added CameraDependent flags to EarLeft/Right

### DIFF
--- a/scripts/OutfitConfig.reds
+++ b/scripts/OutfitConfig.reds
@@ -73,11 +73,11 @@ public abstract class OutfitConfig {
         ExtraSlotConfig.Create(n"OutfitSlots.Wreath", 0, t"AttachmentSlots.Eyes"),
 
         // Ears
-        ExtraSlotConfig.Create(n"OutfitSlots.EarLeft", 0),
-        ExtraSlotConfig.Create(n"OutfitSlots.EarRight", 0),
+        ExtraSlotConfig.Create(n"OutfitSlots.EarLeft", 0, t"", [ExtraSlotFlag.CameraDependent]),
+        ExtraSlotConfig.Create(n"OutfitSlots.EarRight", 0, t"", [ExtraSlotFlag.CameraDependent]),
 
         // Neck
-        ExtraSlotConfig.Create(n"OutfitSlots.Neckwear", 0),
+        ExtraSlotConfig.Create(n"OutfitSlots.Neckwear", 0, t"", [ExtraSlotFlag.CameraDependent]),
         ExtraSlotConfig.Create(n"OutfitSlots.NecklaceTight", 0),
         ExtraSlotConfig.Create(n"OutfitSlots.NecklaceShort", 0),
         ExtraSlotConfig.Create(n"OutfitSlots.NecklaceLong", 0),


### PR DESCRIPTION
..and also included your added flag to Neckwear.

Context: https://discord.com/channels/717692382849663036/1053986629099999292/1074725431531536464

Why I propose this addition:
I also have physics earrings on EarLeft and EarRight that dangle--so I had to blank them in FPP or else they will appear and be annoying. 



